### PR TITLE
Add choseCalculator2.pug page with two buttons link to calculators

### DIFF
--- a/src/components/capitalRaiseCalculator/templates/choseCalculator2.pug
+++ b/src/components/capitalRaiseCalculator/templates/choseCalculator2.pug
@@ -1,0 +1,45 @@
+include ../../../templates/mixins.pug
+
++breadcrumbs('Startup Business Valuation Calculator ', 'New startup',
+    [
+        ['Home', '/'],
+        ["What's My Business Worth?", '/'],
+        ["New Startup", '']
+    ]
+)
+
+.container.calculator-container
+    .row
+        .offset-lg-3.col-lg-6
+            .warning-block.m0
+                i.fa.fa-exclamation-triangle 
+                span.warning-text 
+                    | There are two types of securities your business can issue on GrowthFountain: 
+                    b Common Equity
+                    | &nbsp;or&nbsp;
+                    b PayBack Share.
+
+    .row
+        .offset-lg-3.col-lg-6.mt45
+            p
+                b &nbsp; Common Equity
+                |  represents an ownership share in your business. If your Company is not expecting to generate positive cash flow for the first 12-24 months, or if you expect to reinvest the cash your business generates for the first several years, then Common Equity might be the right security for your Company.
+
+    .row
+        .offset-lg-3.col-lg-6.text-sm-center.mt25
+            a(
+                href="/calculator/capitalraise/intro"
+            ).btn.btn-primary.text-uppercase Startup Business Valuation Calculator
+
+
+    .row
+        .offset-lg-3.col-lg-6.mt45
+            p 
+                b PayBack Share &nbsp;
+                | is a GrowthFountain created revenue sharing security; it is a form of investment contract in which the Company shares 5% of its revenue annually with investors. If you expect your business to produce positive cash flow right out of the gate and don’t intend to reinvest in expansion, PayBack Share may be a good option for you.
+
+    .row
+        .offset-lg-3.col-lg-6.text-sm-center.mt25
+            a(
+                href="/calculator/paybackshare/step-1"
+            ).btn.btn-primary.text-uppercase payback share calculator


### PR DESCRIPTION

@vladyslav2 @MariaKravchuk  @rkuleshov-corevalue 

This should be second page after clicked on How Much Should I Raise? in main menu


(page added in folder components/capitalraisecalculator/template)

![_002](https://cloud.githubusercontent.com/assets/8603994/18488091/a268a8bc-7a00-11e6-97a3-b96a6de19b5d.png)
